### PR TITLE
Merge pull request #2 from javvlon/feature/laravel-10-compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "illuminate/support": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "autoload": {


### PR DESCRIPTION
Changes: The write method now accepts a Monolog\LogRecord object instead of an array