### PR TITLE
Changes: The write method now accepts a Monolog\LogRecord object instead of an array.

### DIFF
--- a/src/GoogleChatLogger.php
+++ b/src/GoogleChatLogger.php
@@ -39,12 +39,12 @@ class GoogleChatLogger extends AbstractProcessingHandler
         $message = [
             'text' => sprintf(
                 "*[%s]* %s (%s) %s\n%s\n%s",
-                $record['level_name'],
+                $record->level->getName(),
                 env('APP_NAME'),
                 env('APP_ENV'),
-                $record['datetime']->format('Y-m-d H:i:s'),
-                $record['message'],
-                $record['context'] ? json_encode($record['context'], JSON_PRETTY_PRINT) : ''
+                $record->datetime->format('Y-m-d H:i:s'),
+                $record->message,
+                $record->context ? json_encode($record->context, JSON_PRETTY_PRINT) : ''
             )
         ];
 


### PR DESCRIPTION
The write method now accepts a Monolog\LogRecord object instead of an array. You can access the log data through the LogRecord object (e.g., $record->message, $record->context, etc.).